### PR TITLE
Fix: Selection Logic for Multi-Specification Products with Out-of-Stock Variants

### DIFF
--- a/app/scraping/handlers/variant_scraper.py
+++ b/app/scraping/handlers/variant_scraper.py
@@ -55,10 +55,11 @@ class VariantScraper:
         return price, stock
 
     def select_and_scrape(self, sb, option_categories, selected_options=None):
+        print(option_categories)
         if selected_options is None:
             selected_options = {}
 
-        if not option_categories:
+        if not option_categories: # 如果在最後一層選單
             price, stock = self.scrape_price_and_stock(sb)
             self.results.append({
                 "options": selected_options,
@@ -70,7 +71,7 @@ class VariantScraper:
 
         current_category = option_categories[0]
         buttons = self.get_option_buttons(sb, current_category)
-        for btn in buttons:
+        for idx, btn in enumerate(buttons):
             try:
                 btn.save_to_dom()
                 sb.sleep(1)
@@ -83,10 +84,16 @@ class VariantScraper:
             except Exception as e:
                 print(f"[ERROR] Failed to select option for category '{current_category}': {e}")
                 continue
-
+            
             self.select_and_scrape(
                 sb, 
                 option_categories[1:], 
                 {**selected_options, current_category: btn.get_attribute("aria-label")}
-            )
+            )            
+            
+            if idx == len(buttons)-1: #deselect button if it's the end of second layer
+                btn.save_to_dom()
+                sb.sleep(1)
+                btn.mouse_click()
+                sb.sleep(1)
 

--- a/app/scraping/handlers/variant_scraper.py
+++ b/app/scraping/handlers/variant_scraper.py
@@ -55,11 +55,10 @@ class VariantScraper:
         return price, stock
 
     def select_and_scrape(self, sb, option_categories, selected_options=None):
-        print(option_categories)
         if selected_options is None:
             selected_options = {}
 
-        if not option_categories: # 如果在最後一層選單
+        if not option_categories:
             price, stock = self.scrape_price_and_stock(sb)
             self.results.append({
                 "options": selected_options,


### PR DESCRIPTION
The code interacts with the site. I assume that the first specification option is color (e.g., red, blue), and the second specification is size (e.g., S, M, L). The program's logic is to first select a color (e.g., red), then iterate through the size options in the order of S → M → L. Ideally, after completing this sequence, the program should return to the first specification (color) and select the next color.

However, if "blue L" is out of stock, the blue option becomes unclickable. According to the current program logic, only the information for the red option will be collected. The blue option can only be selected again after deselecting the L size button.

![testforbuttondisable-ver6](https://github.com/user-attachments/assets/6206ab4d-b7b4-47f6-af2e-97231d1bd59c)

I just added a condition to deselect the button when reaching the last option in the second level.

